### PR TITLE
ux: remove artificial timeout to preserve Discord's thinking indicator

### DIFF
--- a/helpers/safeReply.js
+++ b/helpers/safeReply.js
@@ -39,18 +39,13 @@ async function safeReply(interaction, handler, options = {}) {
       }
     }
 
-    // Execute the handler function with timeout protection
+    // Execute the handler function without timeout to preserve Discord's thinking indicator
     try {
-      const handlerPromise = handler();
-      const timeoutPromise = new Promise((_, reject) => 
-        setTimeout(() => reject(new Error('Handler execution timeout')), 8000)
-      );
-      
-      await Promise.race([handlerPromise, timeoutPromise]);
+      await handler();
       return true;
     } catch (handlerError) {
       // Handle network errors in the command execution
-      if (handlerError.code === 'EAI_AGAIN' || handlerError.message === 'Handler execution timeout') {
+      if (handlerError.code === 'EAI_AGAIN') {
         console.error(`🌐 Network error during command execution: ${handlerError.message}`);
         
         // Try to notify the user if the connection is back


### PR DESCRIPTION
Remove 8-second handler timeout that interrupted Discord's natural loading spinner. Users now see consistent "thinking" state until completion, improving UX for long-running commands while maintaining network error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the timeout mechanism for handler execution, allowing processes to run without interruption.
  - Updated error handling to reflect the removal of the timeout.
  - Clarified comments regarding handler execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->